### PR TITLE
WIP: Adafruit nRF52 Feather Integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/platformio/builder-framework-mbed
 [submodule "builder/frameworks/arduino"]
 	path = builder/frameworks/arduino
-	url = https://github.com/platformio/builder-framework-arduino-nrf5.git
+	url = git@github.com:jeremypoulter/builder-framework-arduino-nrf5.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/platformio/builder-framework-mbed
 [submodule "builder/frameworks/arduino"]
 	path = builder/frameworks/arduino
-	url = git@github.com:jeremypoulter/builder-framework-arduino-nrf5.git
+	url = https://github.com/jeremypoulter/builder-framework-arduino-nrf5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ python:
 
 env:
   - PLATFORMIO_PROJECT_DIR=examples/arduino-blink
-  - PLATFORMIO_PROJECT_DIR=examples/arduino-ble-led
-  - PLATFORMIO_PROJECT_DIR=examples/mbed-ble-thermometer
-  - PLATFORMIO_PROJECT_DIR=examples/mbed-blink
-  - PLATFORMIO_PROJECT_DIR=examples/mbed-dsp
-  - PLATFORMIO_PROJECT_DIR=examples/mbed-events
-  - PLATFORMIO_PROJECT_DIR=examples/mbed-rtos
-  - PLATFORMIO_PROJECT_DIR=examples/mbed-serial
+#  - PLATFORMIO_PROJECT_DIR=examples/arduino-ble-led
+#  - PLATFORMIO_PROJECT_DIR=examples/mbed-ble-thermometer
+#  - PLATFORMIO_PROJECT_DIR=examples/mbed-blink
+#  - PLATFORMIO_PROJECT_DIR=examples/mbed-dsp
+#  - PLATFORMIO_PROJECT_DIR=examples/mbed-events
+#  - PLATFORMIO_PROJECT_DIR=examples/mbed-rtos
+#  - PLATFORMIO_PROJECT_DIR=examples/mbed-serial
 
 install:
   - pip install -U https://github.com/platformio/platformio/archive/develop.zip

--- a/boards/adafruit_feather_nrf52.json
+++ b/boards/adafruit_feather_nrf52.json
@@ -4,8 +4,8 @@
     "cpu": "cortex-m4",
     "extra_flags": "-DARDUINO_FEATHER52",
     "f_cpu": "64000000L",
+    "ldscript": "bluefruit52_s132_5.1.0.ld",
     "mcu": "nrf52832",
-    "ldscript": "nrf52_xxaa.ld",
     "variant": "feather52"
   },
   "connectivity": [

--- a/boards/adafruit_feather_nrf52.json
+++ b/boards/adafruit_feather_nrf52.json
@@ -12,6 +12,7 @@
     "bluetooth"
   ],
   "debug": {
+    "jlink_device": "nRF52832_xxAA",
     "default_tools": [
       "jlink"
     ],

--- a/boards/adafruit_feather_nrf52.json
+++ b/boards/adafruit_feather_nrf52.json
@@ -25,13 +25,11 @@
   "upload": {
     "maximum_ram_size": 65536,
     "maximum_size": 524288,
+    "require_upload_port": true,
+    "speed": 115200,
     "protocol": "nrfutil",
     "protocols": [
-      "jlink",
-      "nrfjprog",
-      "nrfutilx",
-      "stlink",
-      "blackmagic"
+      "nrfutil"
     ]
   },
   "url": "https://www.adafruit.com/product/3406",

--- a/boards/adafruit_feather_nrf52.json
+++ b/boards/adafruit_feather_nrf52.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DARDUINO_FEATHER52",
+    "f_cpu": "64000000L",
+    "mcu": "nrf52832",
+    "ldscript": "nrf52_xxaa.ld",
+    "variant": "feather52"
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "default_tools": [
+      "jlink"
+    ],
+    "onboard_tools": [
+      "jlink"
+    ]
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Adafruit Bluefruit nRF52 Feather",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 524288,
+    "protocol": "nrfjprog",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "stlink",
+      "blackmagic"
+    ]
+  },
+  "url": "https://www.adafruit.com/product/3406",
+  "vendor": "Adafruit"
+}

--- a/boards/adafruit_feather_nrf52.json
+++ b/boards/adafruit_feather_nrf52.json
@@ -27,9 +27,10 @@
     "maximum_size": 524288,
     "require_upload_port": true,
     "speed": 115200,
-    "protocol": "nrfutil",
+    "protocol": "jlink",
     "protocols": [
-      "nrfutil"
+      "nrfutil",
+      "jlink"
     ]
   },
   "url": "https://www.adafruit.com/product/3406",

--- a/boards/adafruit_feather_nrf52.json
+++ b/boards/adafruit_feather_nrf52.json
@@ -9,14 +9,12 @@
     "variant": "feather52"
   },
   "connectivity": [
-    "bluetooth"
+    "bluetooth",
+    "nfc"
   ],
   "debug": {
     "jlink_device": "nRF52832_xxAA",
     "default_tools": [
-      "jlink"
-    ],
-    "onboard_tools": [
       "jlink"
     ]
   },
@@ -27,10 +25,11 @@
   "upload": {
     "maximum_ram_size": 65536,
     "maximum_size": 524288,
-    "protocol": "nrfjprog",
+    "protocol": "nrfutil",
     "protocols": [
       "jlink",
       "nrfjprog",
+      "nrfutilx",
       "stlink",
       "blackmagic"
     ]

--- a/boards/adafruit_feather_nrf52832.json
+++ b/boards/adafruit_feather_nrf52832.json
@@ -2,11 +2,11 @@
   "build": {
     "core": "nRF5",
     "cpu": "cortex-m4",
-    "extra_flags": "-DARDUINO_FEATHER52",
+    "extra_flags": "-DARDUINO_FEATHER52832 -DNRF52832_XXAA",
     "f_cpu": "64000000L",
-    "ldscript": "bluefruit52_s132_5.1.0.ld",
+    "ldscript": "nrf52832_s132_v6.ld",
     "mcu": "nrf52832",
-    "variant": "feather52"
+    "variant": "feather_nrf52832"
   },
   "connectivity": [
     "bluetooth",
@@ -21,7 +21,7 @@
   "frameworks": [
     "arduino"
   ],
-  "name": "Adafruit Bluefruit nRF52 Feather",
+  "name": "Adafruit Bluefruit nRF52832 Feather",
   "upload": {
     "maximum_ram_size": 65536,
     "maximum_size": 524288,

--- a/builder/main.py
+++ b/builder/main.py
@@ -139,7 +139,6 @@ env.Append(
         )
     )
 )
-#dfu genpkg --dev-type 0x0052 --sd-req 0x00A5 --application .pioenvs/bluefruit_nrf52/firmware.hex .pioenvs/bluefruit_nrf52/firmware.zip
 
 #
 # Target: Build executable and linkable firmware
@@ -227,13 +226,14 @@ elif upload_protocol == "nrfutil":
             "dfu",
             "serial",
             "-p",
-            "/dev/ttyUSB0",
+            "$UPLOAD_PORT",
             "-b",
-            "115200"
+            "$UPLOAD_SPEED"
         ],
         UPLOADCMD="$UPLOADER $UPLOADERFLAGS -pkg $SOURCE"
     )
-    upload_actions = [env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]
+    upload_actions = [env.VerboseAction(env.AutodetectUploadPort, "Looking for upload port..."),
+                      env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]
 
 elif upload_protocol.startswith("jlink"):
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -156,25 +156,28 @@ env.Append(
 
 upload_protocol = env.subst("$UPLOAD_PROTOCOL")
 
+
 target_elf = None
 if "nobuild" in COMMAND_LINE_TARGETS:
     target_firm = join("$BUILD_DIR", "${PROGNAME}.hex")
 else:
     target_elf = env.BuildProgram()
+    dfu_package = env.PackageDfu(
+        join("$BUILD_DIR", "${PROGNAME}"),
+        env.ElfToHex(join("$BUILD_DIR", "${PROGNAME}"), target_elf))
     if "SOFTDEVICEHEX" in env:
         target_firm = env.MergeHex(
             join("$BUILD_DIR", "${PROGNAME}"),
             env.ElfToHex(join("$BUILD_DIR", "userfirmware"), target_elf))
     elif "nrfutil" == upload_protocol:
-        target_firm = env.PackageDfu(
-            join("$BUILD_DIR", "${PROGNAME}"),
-            env.ElfToHex(join("$BUILD_DIR", "${PROGNAME}"), target_elf))
+        target_firm = dfu_package
     else:
         target_firm = env.SignBin(
             join("$BUILD_DIR", "${PROGNAME}"),
             env.ElfToBin(join("$BUILD_DIR", "${PROGNAME}"), target_elf))
 
 AlwaysBuild(env.Alias("nobuild", target_firm))
+AlwaysBuild(env.Alias("dfu", dfu_package))
 target_buildprog = env.Alias("buildprog", target_firm, target_firm)
 
 #

--- a/builder/main.py
+++ b/builder/main.py
@@ -146,7 +146,8 @@ env.Append(
                 "$TARGET",
                 "$SOURCES"
             ]), "Signing $SOURCES"),
-            suffix="_signature.bin"        )
+            suffix="_signature.bin"
+        )
     )
 )
 

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -7,29 +7,34 @@
 ; Please visit documentation for the other options and examples
 ; http://docs.platformio.org/page/projectconf.html
 
-[env:nrf52_dk]
-platform = nordicnrf52
-framework = arduino
-board = nrf52_dk
-  
-[env:delta_dfbm_nq620]
-platform = nordicnrf52
-framework = arduino
-board = delta_dfbm_nq620
+#[env:nrf52_dk]
+#platform = nordicnrf52
+#framework = arduino
+#board = nrf52_dk
+#  
+#[env:delta_dfbm_nq620]
+#platform = nordicnrf52
+#framework = arduino
+#board = delta_dfbm_nq620
+#
+#[env:redbear_blenano2]
+#platform = nordicnrf52
+#framework = arduino
+#board = redbear_blenano2
+# 
+#[env:redbear_blend2]
+#platform = nordicnrf52
+#framework = arduino
+#board = redbear_blend2
+#build_flags = -DNRF52_S132
+#
+#[env:stct_nrf52_minidev]
+#platform = nordicnrf52
+#framework = arduino
+#board = stct_nrf52_minidev
+#build_flags = -DNRF52_S132
 
-[env:redbear_blenano2]
-platform = nordicnrf52
+[env:adafruit_feather_nrf52]
+platform = nordicnrf52-adafruit
 framework = arduino
-board = redbear_blenano2
- 
-[env:redbear_blend2]
-platform = nordicnrf52
-framework = arduino
-board = redbear_blend2
-build_flags = -DNRF52_S132
-
-[env:stct_nrf52_minidev]
-platform = nordicnrf52
-framework = arduino
-board = stct_nrf52_minidev
-build_flags = -DNRF52_S132
+board = adafruit_feather_nrf52

--- a/platform.json
+++ b/platform.json
@@ -1,6 +1,6 @@
 {
-  "name": "nordicnrf52",
-  "title": "Nordic nRF52",
+  "name": "nordicnrf52-adafruit",
+  "title": "Nordic nRF52 (Adafruit)",
   "description": "The nRF52 Series are built for speed to carry out increasingly complex tasks in the shortest possible time and return to sleep, conserving precious battery power. They have a Cortex-M4F processor and are the most capable Bluetooth Smart SoCs on the market. ",
   "url": "https://www.nordicsemi.com/Products/nRF52-Series-SoC",
   "homepage": "http://platformio.org/platforms/nordicnrf52",
@@ -19,12 +19,8 @@
   ],
   "frameworks": {
     "arduino": {
-      "package": "framework-arduinonordicnrf5",
+      "package": "framework-arduinoadafruitnrf52",
       "script": "builder/frameworks/arduino/arduino.py"
-    },
-    "mbed": {
-      "package": "framework-mbed",
-      "script": "builder/frameworks/mbed/mbed.py"
     }
   },
   "packages": {
@@ -32,15 +28,10 @@
       "type": "toolchain",
       "version": ">=1.60301.0"
     },
-    "framework-mbed": {
+    "framework-arduinoadafruitnrf52": {
       "type": "framework",
       "optional": true,
-      "version": "~4.50707.0"
-    },
-    "framework-arduinonordicnrf5": {
-      "type": "framework",
-      "optional": true,
-      "version": "~0.4.0"
+      "version": "git@github.com:jeremypoulter/Adafruit_nRF52_Arduino.git"
     },
     "tool-sreccat": {
       "version": "~1.164.0"

--- a/platform.json
+++ b/platform.json
@@ -31,7 +31,7 @@
     "framework-arduinoadafruitnrf52": {
       "type": "framework",
       "optional": true,
-      "version": "git@github.com:jeremypoulter/Adafruit_nRF52_Arduino.git"
+      "version": "https://github.com/jeremypoulter/Adafruit_nRF52_Arduino.git"
     },
     "tool-sreccat": {
       "version": "~1.164.0"

--- a/platform.json
+++ b/platform.json
@@ -45,6 +45,11 @@
       "type": "uploader",
       "optional": true,
       "version": "~1.90702.0"
+    },
+    "tool-nrfutil": {
+      "type": "uploader",
+      "optional": true,
+      "version": "https://github.com/NordicSemiconductor/pc-nrfutil.git"
     }
   }
 }

--- a/platform.json
+++ b/platform.json
@@ -49,7 +49,7 @@
     "tool-nrfutil": {
       "type": "uploader",
       "optional": true,
-      "version": "https://github.com/NordicSemiconductor/pc-nrfutil.git"
+      "version": "https://github.com/NordicSemiconductor/pc-nrfutil.git#0_5_2"
     }
   }
 }

--- a/platform.py
+++ b/platform.py
@@ -15,7 +15,7 @@
 from platformio.managers.platform import PlatformBase
 
 
-class Nordicnrf52Platform(PlatformBase):
+class Nordicnrf52adafruitPlatform(PlatformBase):
 
     def is_embedded(self):
         return True


### PR DESCRIPTION
**WORK IN PROGRESS/REQUEST FOR COMMENT**

I have been working on integrating Adafruit's nRF52 SDK into Platform IO to use as an alternative to @sandeepmistry's mainly due to the support for Central mode. I have got to a point where I can compile (but still have a linker issue) but before I go much further down the road I wanted to get some input on if this is the the right direction.

My current thinking is that this will have to exist as a separate platform to the current one as I can not see an easy way of referencing multiple arduino cores, but please let me know if there is.
