### PR TITLE
Fix to work with new OpenOCD package

### DIFF
--- a/boards/nrf52840_dk.json
+++ b/boards/nrf52840_dk.json
@@ -20,7 +20,7 @@
           "arguments": [
             "-f", "scripts/interface/jlink.cfg",
             "-c", "transport select swd",
-            "-f", "scripts/target/nrf52_arduino.cfg"
+            "-f", "scripts/target/nrf52.cfg"
           ]
         },
         "onboard": true

--- a/boards/nrf52_dk.json
+++ b/boards/nrf52_dk.json
@@ -20,7 +20,7 @@
           "arguments": [
             "-f", "scripts/interface/jlink.cfg",
             "-c", "transport select swd",
-            "-f", "scripts/target/nrf52_arduino.cfg"
+            "-f", "scripts/target/nrf52.cfg"
           ]
         },
         "onboard": true


### PR DESCRIPTION
Fixes #13, nrf52_arduino.cfg file is no longer part of the OpenOCD package. nrf52.cfg has the changes that where in nrf52_arduino.cfg so this change changes to use that file. 