### PR TITLE
Correct check for path to adafruit-nrfutil on MacOS

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -32,8 +32,8 @@ if use_adafruit:
     os_platform = sys.platform
     if os_platform == "win32":
         nrfutil_path = join(FRAMEWORK_DIR, "tools", "adafruit-nrfutil", os_platform, "adafruit-nrfutil.exe")
-    elif os_platform == "macos":
-        nrfutil_path = join(FRAMEWORK_DIR, "tools", "adafruit-nrfutil", os_platform, "adafruit-nrfutil")
+    elif os_platform == "darwin":
+        nrfutil_path = join(FRAMEWORK_DIR, "tools", "adafruit-nrfutil", "macos", "adafruit-nrfutil")
     else:
         nrfutil_path = "adafruit-nrfutil"
 else:


### PR DESCRIPTION
This is a fix for #26. It corrects the check for MacOS in the build script and the resulting path to the utility.