### PR TITLE
Add a board definition for SparkFun Pro nRF53840 Mini board

### DIFF
--- a/boards/sparkfun_pro_nrf52840_mini.json
+++ b/boards/sparkfun_pro_nrf52840_mini.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DARDUINO_NRF52840_FEATHER -DNRF52840_XXAA",
+    "f_cpu": "64000000L",
+    "ldscript": "nrf52840_s140_v6.ld",
+    "mcu": "nrf52840",
+    "variant": "pca10056",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "6.1.1",
+      "sd_fwid": "0x00B6"
+    },
+    "bootloader": {
+      "settings_addr": "0xFF000"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "onboard_tools": [
+      "jlink"
+    ],
+    "svd_path": "nrf52.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "SparkFun Pro nRF52840 Mini",
+  "upload": {
+    "maximum_ram_size": 248832,
+    "maximum_size": 815104,
+    "require_upload_port": true,
+    "speed": 115200,
+    "protocol": "nrfutil",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "nrfutil"
+    ]
+  },
+  "url": "https://www.sparkfun.com/products/15025",
+  "vendor": "SparkFun"
+}


### PR DESCRIPTION
This PR adds a board definition file for [SparkFun Pro nRF53840 Mini](https://www.sparkfun.com/products/15025).