### PR TITLE
Wrap nrfutil_path in quotes to avoid crash when the path includes spaces

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -114,7 +114,7 @@ if use_adafruit:
         BUILDERS=dict(
             PackageDfu=Builder(
                 action=env.VerboseAction(" ".join([
-                    nrfutil_path,
+                    "".join(["\"",nrfutil_path, "\""]), # Surround path with quotes to resolve issues when the path has spaces.
                     "dfu",
                     "genpkg",
                     "--dev-type",

--- a/builder/main.py
+++ b/builder/main.py
@@ -31,7 +31,8 @@ if use_adafruit:
 
     os_platform = sys.platform
     if os_platform == "win32":
-        nrfutil_path = join(FRAMEWORK_DIR, "tools", "adafruit-nrfutil", os_platform, "adafruit-nrfutil.exe")
+        # Surround path with quotes to resolve issues when the path has spaces.
+        nrfutil_path = "".join(["\"",join(FRAMEWORK_DIR, "tools", "adafruit-nrfutil", os_platform, "adafruit-nrfutil.exe"), "\""])
     elif os_platform == "darwin":
         nrfutil_path = join(FRAMEWORK_DIR, "tools", "adafruit-nrfutil", "macos", "adafruit-nrfutil")
     else:
@@ -114,7 +115,7 @@ if use_adafruit:
         BUILDERS=dict(
             PackageDfu=Builder(
                 action=env.VerboseAction(" ".join([
-                    "".join(["\"",nrfutil_path, "\""]), # Surround path with quotes to resolve issues when the path has spaces.
+                    nrfutil_path,
                     "dfu",
                     "genpkg",
                     "--dev-type",


### PR DESCRIPTION
I was getting an error when trying to build on my machine where the user name has a space between <first> and <last>. The error I was getting is: 

    'C:\Users\Scott' is not recognized as an internal or external command, operable program or batch file.
    *** [.pio\build\adafruit_feather_nrf52832\firmware.zip] Error 1

I only tested this for paths with a space and paths without a space.

