### PR TITLE
Add support for cmsis-dap on feather-nrf52840

### DIFF
--- a/boards/adafruit_feather_nrf52840.json
+++ b/boards/adafruit_feather_nrf52840.json
@@ -61,7 +61,8 @@
       "jlink",
       "nrfjprog",
       "nrfutil",
-      "stlink"
+      "stlink",
+      "cmsis-dap"
     ],
     "use_1200bps_touch": true,
     "require_upload_port": true,


### PR DESCRIPTION
Just tried this locally, and it works fine for uploading and debugging.