### PR TITLE
Add support for blackmagic on feather-nrf52840

### DIFF
--- a/boards/adafruit_feather_nrf52840.json
+++ b/boards/adafruit_feather_nrf52840.json
@@ -63,7 +63,8 @@
       "nrfjprog",
       "nrfutil",
       "stlink",
-      "cmsis-dap"
+      "cmsis-dap",
+      "blackmagic"
     ],
     "use_1200bps_touch": true,
     "require_upload_port": true,


### PR DESCRIPTION
I can confirm that the feather is working pretty well with the blackmagic probe. Before the new zephyr version which support the feather out of the box I was using the DK with blackmagic and everything works, except the wrong dt mapping of course.

Previous working configuration for the feather with blackmagic:

```
[env:nrf52840_dk]
platform = nordicnrf52
board = nrf52840_dk
framework = zephyr
...
```