### PR TITLE
board: add reel_board and reel_board_v2

### DIFF
--- a/boards/reel_board.json
+++ b/boards/reel_board.json
@@ -1,0 +1,45 @@
+{
+  "build": {
+    "cpu": "cortex-m4",
+    "f_cpu": "64000000L",
+    "mcu": "nrf52840",
+    "hwids": [
+      [
+        "0x0D28",
+        "0x0204"
+      ]
+    ],
+    "zephyr": {
+      "variant": "reel_board"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "onboard_tools": [
+      "cmsis-dap"
+    ],
+    "svd_path": "nrf52840.svd"
+  },
+  "frameworks": [
+    "zephyr"
+  ],
+  "name": "reel_board",
+  "upload": {
+    "maximum_ram_size": 262144,
+    "maximum_size": 1048576,
+    "protocol": "cmsis-dap",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "blackmagic",
+      "cmsis-dap",
+      "stlink",
+      "mbed"
+    ]
+  },
+  "url": "https://www.phytec.eu/reelboard",
+  "vendor": "PHYTEC"
+}

--- a/boards/reel_board_v2.json
+++ b/boards/reel_board_v2.json
@@ -1,0 +1,45 @@
+{
+  "build": {
+    "cpu": "cortex-m4",
+    "f_cpu": "64000000L",
+    "mcu": "nrf52840",
+    "hwids": [
+      [
+        "0x0D28",
+        "0x0204"
+      ]
+    ],
+    "zephyr": {
+      "variant": "reel_board_v2"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "onboard_tools": [
+      "cmsis-dap"
+    ],
+    "svd_path": "nrf52840.svd"
+  },
+  "frameworks": [
+    "zephyr"
+  ],
+  "name": "reel_board_v2",
+  "upload": {
+    "maximum_ram_size": 262144,
+    "maximum_size": 1048576,
+    "protocol": "cmsis-dap",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "blackmagic",
+      "cmsis-dap",
+      "stlink",
+      "mbed"
+    ]
+  },
+  "url": "https://www.phytec.eu/reelboard",
+  "vendor": "PHYTEC"
+}


### PR DESCRIPTION
This PR adds support for reel_board and reel_board_v2. The main platform for the reel_board is Zephyr. More information can be found in the [documentation page](https://docs.zephyrproject.org/latest/boards/arm/reel_board/doc/index.html) of the reel board within the Zephyr project.

I tested the boards here locally and building, debugging and serial monitor works for me. Is there a way to make a baudrate of 115200 the default for this board? Zephyr uses 115200 for most of the examples.

reel_board and reel_board_v2 differ in the passive display being used. I created two different boards. Not sure if there is a more elegant way to go?