### PR TITLE
Add Zephyr build info to BBC Microbit V2

### DIFF
--- a/boards/bbcmicrobit_v2.json
+++ b/boards/bbcmicrobit_v2.json
@@ -8,7 +8,10 @@
     "extra_flags": "-DARDUINO_BBC_MICROBIT_V2 -DNRF52833_XXAA",
     "f_cpu": "64000000L",
     "mcu": "nrf52833",
-    "variant": "BBCmicrobitV2"
+    "variant": "BBCmicrobitV2",
+    "zephyr": {
+      "variant": "bbc_microbit_v2"
+    }
   },
   "connectivity": [
     "bluetooth"
@@ -25,7 +28,8 @@
     "jlink_device": "nRF52833_xxAA"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "zephyr"
   ],
   "name": "BBC micro:bit V2",
   "upload": {


### PR DESCRIPTION
The latest commit has updated the Zephyr version to v2.5.0, but this board was not added to the supported Zephyr board lists.

It is supported per https://github.com/zephyrproject-rtos/zephyr/tree/zephyr-v2.5.0/boards/arm/bbc_microbit_v2. 

Per https://community.platformio.org/t/unable-to-build-debug-bbc-micro-bit-v2-using-platformio-with-zephyr-2-5-0/19652 the changes to this board manifest result in a working firmware, too :) 