### PR TITLE
Correct RAM size for BBC Micro:Bit v2

### DIFF
--- a/boards/bbcmicrobit_v2.json
+++ b/boards/bbcmicrobit_v2.json
@@ -33,7 +33,7 @@
   ],
   "name": "BBC micro:bit V2",
   "upload": {
-    "maximum_ram_size": 65536,
+    "maximum_ram_size": 131072,
     "maximum_size": 524288,
     "protocol": "cmsis-dap",
     "protocols": [


### PR DESCRIPTION
Per https://raspberrypi.dk/wp-content/uploads/2020/10/BBC-microbit-v2-datasheet-v1.2.pdf and https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52833 the nRF52833 chip has 128KByte of SRAM.

As noted in https://community.platformio.org/t/unable-to-build-debug-bbc-micro-bit-v2-using-platformio-with-zephyr-2-5-0/19652/7?u=maxgerhardt and cross-checked by me per links above.