### PR TITLE
Enable mbed-os support for Nano 33 BLE

### DIFF
--- a/boards/nano33ble.json
+++ b/boards/nano33ble.json
@@ -18,7 +18,8 @@
       ]
     ],
     "mcu": "nrf52840",
-    "variant": "ARDUINO_NANO33BLE"
+    "variant": "ARDUINO_NANO33BLE",
+    "mbed_variant": "ARDUINO_NANO33BLE"
   },
   "connectivity": [
     "bluetooth"
@@ -29,7 +30,8 @@
     "svd_path": "nrf52840.svd"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "mbed"
   ],
   "name": "Arduino Nano 33 BLE",
   "upload": {


### PR DESCRIPTION
Supported since mbed-os 6.2.0 (and also in the used 6.6.0) per https://github.com/ARMmbed/mbed-os/tree/mbed-os-6.6.0/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840.

Tested **compilation** with a minimal 

``` 
[env:nano33ble]
platform = nordicnrf52
board = nano33ble
framework = mbed
```
and `src\main.cpp`

```
#include "mbed.h"
int main() {
    DigitalOut led(LED_BUILTIN);
    while(true) {
        led = 1;
        ThisThread::sleep_for(chrono::milliseconds(1000));
        led = 0; 
        ThisThread::sleep_for(chrono::milliseconds(1000));
    }
    return 0;
}
```

which compiles.

```
Building .pio\build\nano33ble\firmware.bin
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [          ]   4.2% (used 11032 bytes from 262144 bytes)
Flash: [          ]   3.7% (used 36352 bytes from 983040 bytes)
================= [SUCCESS] Took 22.59 seconds =================
```

I don't have the board to test but there shouldn't be any major problems -- the board support is there in mainline mbed-os.

Note that the Arduino-mbed core also works on mbed-os base but applies [some patches](https://github.com/arduino/ArduinoCore-mbed/tree/master/patches). Most of those seem to be for the Portenta H7 though, so they shouldn't impede operation for the Nano 33 BLE. 