### PR TITLE
Add support for nRF52840 USB Dongle

### DIFF
--- a/boards/nrf52840_dongle.json
+++ b/boards/nrf52840_dongle.json
@@ -1,0 +1,34 @@
+{
+    "build": {
+      "core": "nRF5",
+      "cpu": "cortex-m4",
+      "f_cpu": "64000000L",
+      "mcu": "nrf52840",
+      "variant": "nRF52840DONGLE",
+      "zephyr": {
+         "variant": "nrf52840dongle_nrf52840"
+      }
+    },
+    "connectivity": [
+      "bluetooth"
+    ],
+    "debug": {
+      "jlink_device": "nRF52840_xxAA",
+      "svd_path": "nrf52840.svd"
+    },
+    "frameworks": [
+      "zephyr"
+    ],
+    "name": "Nordic nRF52840 Dongle",
+    "upload": {
+      "maximum_ram_size": 262144,
+      "maximum_size": 1048576,
+      "protocol": "nrfutil",
+      "protocols": [
+        "nrfutil"
+      ]
+    },
+    "url": "https://www.nordicsemi.com/Products/Development-hardware/nRF52840-Dongle",
+    "vendor": "Nordic"
+  }
+  


### PR DESCRIPTION
The nRF52840 Dongle is small USB key commonly used with nRF Connect, although apps can be built for it using Zephyr OS.
(Arduino and Mbed don't support this board)

It doesn't come with a JTAG debugger of any sort, thus DFU is the only method supported for programming.

DFU uploads are performed using `nrfutil`, which can be installed using Python's package manager and simply issuing `pip install nrfutil` command.

For development purposed I manually installed nrfutil in PlatformIO's virtual environment and the upload works, but a custom tool (_tool-nrfutil_ maybe?) might be more appropriate.
I didn't tried with Adafruit's nrfutil fork (which can already be installed through PlatformIO).

**Problems**

- Using nrfutil vanilla I can't seem to generate a valid DFU package when selecting a SoftDevice version different from 0x00.

- When generating a DFU package, the application versions string is required. How can I get a custom value from platformio.ini or provide a default one otherwise?