### PR TITLE
Enable inclusion of softdevice

### DIFF
--- a/boards/bbcmicrobit_v2.json
+++ b/boards/bbcmicrobit_v2.json
@@ -5,7 +5,7 @@
     },
     "core": "nRF5",
     "cpu": "cortex-m4",
-    "extra_flags": "-DARDUINO_BBC_MICROBIT_V2 -DNRF52833_XXAA",
+    "extra_flags": "-DARDUINO_BBC_MICROBIT_V2 -DNRF52833_XXAA -DNRF52_S132",
     "f_cpu": "64000000L",
     "mcu": "nrf52833",
     "variant": "BBCmicrobitV2",


### PR DESCRIPTION
Without this flag, the builder script won't include the softdevice needed for bluetooth.

https://github.com/platformio/builder-framework-arduino-nrf5/blob/08ccc03196db3c58fbd52ddd55b20ea406c927ae/nrf5.py#L129-L134

And hence, simple sketches needing bluetooth fail to compile, as e.g.

```ini
[env:bbcmicrobit_v2]
platform = nordicnrf52
board = bbcmicrobit_v2
framework = arduino
lib_deps =
   sandeepmistry/BLEPeripheral@^0.4.0
```
with `src\main.cpp` 

```cpp
#include <Arduino.h>
#include <BLEPeripheral.h>

BLEPeripheral blePeripheral = BLEPeripheral();

void setup(){}
void loop(){}
```
with errors like 

```
Compiling .pio\build\bbcmicrobit_v2\src\main.cpp.o
In file included from .pio\libdeps\bbcmicrobit_v2\BLEPeripheral\src/BLEPeripheral.h:24:0,
                 from src\main.cpp:2:
.pio\libdeps\bbcmicrobit_v2\BLEPeripheral\src/nRF51822.h:11:12: fatal error: ble_gatts.h: No such file or directory
```

I think the soft-device should be enabled by default, especially since the user fix, adding `build_flags = -DNRF52_S132` to the `platformio.ini`, is not documented on [Nordic nRF52](https://docs.platformio.org/en/latest/platforms/nordicnrf52.html).