### PR TITLE
Activate JLink's Zephyr-aware debugging

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -130,7 +130,8 @@ class Nordicnrf52Platform(PlatformBase):
                             "-if", "SWD",
                             "-select", "USB",
                             "-device", debug.get("jlink_device"),
-                            "-port", "2331"
+                            "-port", "2331",
+                            "-rtos", "GDBServer/RTOSPlugin_Zephyr"
                         ],
                         "executable": ("JLinkGDBServerCL.exe"
                                        if platform.system() == "Windows" else


### PR DESCRIPTION
Per https://community.platformio.org/t/is-platformio-nrf52-debugger-zephyr-rtos-aware/26965.

Having this flag there will cause the JLinkGDBSever to load GDBServer/RTOSPlugin_Zephyr.dll (or `.so`) and discover Zephyr-RTOS threads and communicate that to GDB. I.e, Zephyr thread-aware debugging can be done.

A precondition to this though is that 
```
CONFIG_THREAD_MONITOR=y
CONFIG_DEBUG_THREAD_INFO=y
```
is activated in the `zephyr/prj.conf`, otherwise the necessary symbols won't be there for the JLink tool to find.

![grafik](https://user-images.githubusercontent.com/26485477/161449468-e78bad02-ac38-4eaa-9aa1-a92eb90d9bf2.png)
