### PR TITLE
Add Zephyr to Nano 33 BLE board

### DIFF
--- a/boards/nano33ble.json
+++ b/boards/nano33ble.json
@@ -18,7 +18,10 @@
       ]
     ],
     "mcu": "nrf52840",
-    "variant": "ARDUINO_NANO33BLE"
+    "variant": "ARDUINO_NANO33BLE",
+    "zephyr": {
+       "variant": "arduino_nano_33_ble"
+    }
   },
   "connectivity": [
     "bluetooth"
@@ -29,7 +32,8 @@
     "svd_path": "nrf52840.svd"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "zephyr"
   ],
   "name": "Arduino Nano 33 BLE",
   "upload": {


### PR DESCRIPTION
Zephyr supports Nano 33 33, add it as a build option.

I was able to upload the blink sketch using this config.

Zephyr docs: https://docs.zephyrproject.org/3.2.0/boards/arm/arduino_nano_33_ble/doc/index.html