### PR TITLE
Quote path arguments to nrfjprog

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -241,7 +241,7 @@ if "DFUBOOTHEX" in env:
         None,
         [
             env.VerboseAction(
-                "nrfjprog --program $DFUBOOTHEX -f nrf52 --chiperase",
+                "nrfjprog --program \"$DFUBOOTHEX\" -f nrf52 --chiperase",
                 "Uploading $DFUBOOTHEX",
             ),
             env.VerboseAction(
@@ -314,7 +314,7 @@ elif upload_protocol == "nrfjprog":
             "--sectorerase" if "DFUBOOTHEX" in env else "--chiperase",
             "--reset"
         ],
-        UPLOADCMD="$UPLOADER $UPLOADERFLAGS --program $SOURCE"
+        UPLOADCMD="$UPLOADER $UPLOADERFLAGS --program \"$SOURCE\""
     )
     upload_actions = [env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]
 


### PR DESCRIPTION
`nrfjprog` doesn't like spaces in file paths, which makes actions like "burn bootloader" fail if you're on windows and have a space in your username. Quoting the argument fixes this.

I looked through this file and found anywhere it looks like `nrfjprog` is taking in file path arguments. There could still be other usages in other files.

**Help needed**: I'm not actually sure how to test this PR. It looks pretty simple, but I'd be happier knowing that it works.