### PR TITLE
RAK4631 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "builder/frameworks/arduino"]
 	path = builder/frameworks/arduino
-	url = https://github.com/platformio/builder-framework-arduino-nrf5.git
+	url = https://github.com/maxgerhardt/builder-framework-arduino-nrf5.git
+	branch = patch-3

--- a/boards/wiscore_rak4631.json
+++ b/boards/wiscore_rak4631.json
@@ -1,0 +1,72 @@
+{
+	"build": {
+		"arduino": {
+			"ldscript": "nrf52840_s140_v6.ld"
+		},
+		"core": "nRF5",
+		"cpu": "cortex-m4",
+		"extra_flags": "-DARDUINO_NRF52840_FEATHER -DNRF52840_XXAA",
+		"f_cpu": "64000000L",
+		"hwids": [
+			[
+				"0x239A",
+				"0x8029"
+			],
+			[
+				"0x239A",
+				"0x0029"
+			],
+			[
+				"0x239A",
+				"0x002A"
+			],
+			[
+				"0x239A",
+				"0x802A"
+			]
+		],
+		"usb_product": "WisCore RAK4631 Board",
+		"mcu": "nrf52840",
+		"variant": "WisCore_RAK4631_Board",
+		"bsp": {
+			"name": "adafruit"
+		},
+		"softdevice": {
+			"sd_flags": "-DS140",
+			"sd_name": "s140",
+			"sd_version": "6.1.1",
+			"sd_fwid": "0x00B6"
+		},
+		"bootloader": {
+			"settings_addr": "0xFF000"
+		}
+	},
+	"connectivity": [
+		"bluetooth"
+	],
+	"debug": {
+		"jlink_device": "nRF52840_xxAA",
+		"svd_path": "nrf52840.svd"
+	},
+	"frameworks": [
+		"arduino"
+	],
+	"name": "WisCore RAK4631 Board",
+	"upload": {
+		"maximum_ram_size": 248832,
+		"maximum_size": 815104,
+		"speed": 115200,
+		"protocol": "nrfutil",
+		"protocols": [
+			"jlink",
+			"nrfjprog",
+			"nrfutil",
+			"stlink"
+		],
+		"use_1200bps_touch": true,
+		"require_upload_port": true,
+		"wait_for_upload_port": true
+	},
+	"url": "https://www.rakwireless.com",
+	"vendor": "RAKwireless"
+}

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -43,3 +43,8 @@ platform = nordicnrf52
 framework = arduino
 board = stct_nrf52_minidev
 build_flags = -DNRF52_S132
+
+[env:wiscore_rak4631]
+platform = nordicnrf52
+framework = arduino
+board = wiscore_rak4631

--- a/examples/arduino-bluefruit-bleuart/platformio.ini
+++ b/examples/arduino-bluefruit-bleuart/platformio.ini
@@ -48,3 +48,9 @@ platform = nordicnrf52
 framework = arduino
 board = adafruit_ledglasses_nrf52840
 monitor_speed = 115200
+
+[env:wiscore_rak4631]
+platform = nordicnrf52
+framework = arduino
+board = wiscore_rak4631
+monitor_speed = 115200

--- a/platform.json
+++ b/platform.json
@@ -59,7 +59,7 @@
       "type": "framework",
       "optional": true,
       "owner": "platformio",
-      "version": "~1.10303.0"
+      "version": "https://github.com/maxgerhardt/RAK-nRF52-Arduino/archive/refs/heads/1.3.3.zip"
     },
     "framework-arduinonordicnrf5": {
       "type": "framework",

--- a/platform.json
+++ b/platform.json
@@ -55,6 +55,12 @@
       "owner": "platformio",
       "version": "~1.10500.0"
     },
+    "framework-arduinoraknrf52": {
+      "type": "framework",
+      "optional": true,
+      "owner": "platformio",
+      "version": "~1.10303.0"
+    },
     "framework-arduinonordicnrf5": {
       "type": "framework",
       "optional": true,

--- a/platform.py
+++ b/platform.py
@@ -37,8 +37,12 @@ class Nordicnrf52Platform(PlatformBase):
 
             if self.board_config(board).get("build.bsp.name",
                                             "nrf5") == "adafruit":
-                self.frameworks["arduino"][
-                    "package"] = "framework-arduinoadafruitnrf52"
+                if board in ("wiscore_rak4631"):
+                    self.frameworks["arduino"][
+                        "package"] = "framework-arduinoraknrf52"
+                else:
+                    self.frameworks["arduino"][
+                        "package"] = "framework-arduinoadafruitnrf52"
                 self.packages["framework-cmsis"]["optional"] = False
                 self.packages["tool-adafruit-nrfutil"]["optional"] = False
 


### PR DESCRIPTION
Adds support for the Wiscore RAK4631 Board and its (from Adafruit) forked core https://github.com/RAKWireless/RAK-nRF52-Arduino in the latest 1.3.3. version.

Attempts to superseed the weird "live-patch" method that RAK does with https://docs.rakwireless.com/Knowledge-Hub/Learn/Board-Support-Package-Installation-in-PlatformIO/#update by introducing a proper package + board definition into mainline.

The package version is the 1.3.3 version with backpatches for the PlatformIO-specific library scripts (https://github.com/maxgerhardt/RAK-nRF52-Arduino/commit/547e46cc8e0a5b907dd0728fbc32b718396b6c46, https://github.com/maxgerhardt/RAK-nRF52-Arduino/commit/758aff9a9b440a1664a76b00532443e05475dff4, https://github.com/maxgerhardt/RAK-nRF52-Arduino/commit/817eadbdf0e7083e1175feb1aba926b2cc75ee7f).

Blink example and Bluefruit example compile normally.

Suggested course of action:
1. Merge https://github.com/platformio/builder-framework-arduino-nrf5/pull/14
2. Readjust builder/frameworks/arduino submodule target here
3. Add framework package to registry, adjust `platform.json`
4. Merge this PR