### PR TITLE
Change to static gcc version for framework-adafruitnrf52 (fixes #191)

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -39,6 +39,7 @@ class Nordicnrf52Platform(PlatformBase):
                                             "nrf5") == "adafruit":
                 self.frameworks["arduino"][
                     "package"] = "framework-arduinoadafruitnrf52"
+                self.packages["toolchain-gccarmnoneeabi"]["version"] = "~1.80201.0"
                 self.packages["framework-cmsis"]["optional"] = False
                 self.packages["tool-adafruit-nrfutil"]["optional"] = False
 


### PR DESCRIPTION
More details here: https://github.com/platformio/platform-nordicnrf52/issues/191

This changes the gcc version for the `framework-arduinoadafruitnrf52` to a newer (1.8) and fixed version than the current "first" optional version (1.7). in order to restore compatibility with the framework's latest release (1.6.0) and its use of `--wrap=realloc` (plus potentially other issues introduced with https://github.com/adafruit/Adafruit_nRF52_Arduino/pull/744 and others)