### PR TITLE
NRF58240DK board fix

### DIFF
--- a/boards/nrf52840_dk.json
+++ b/boards/nrf52840_dk.json
@@ -5,10 +5,10 @@
     },
     "core": "nRF5",
     "cpu": "cortex-m4",
-    "extra_flags": "-DARDUINO_NRF52_DK",
+    "extra_flags": "-DARDUINO_NRF52840_DK -DNRF52840_XXAA",
     "f_cpu": "64000000L",
     "mcu": "nrf52840",
-    "variant": "nRF52DK",
+    "variant": "nRF52840DK",
     "zephyr": {
        "variant": "nrf52840dk_nrf52840"
     }


### PR DESCRIPTION
Fixes the board variant used by the NRF52840DK board
The current configured target is the NRF52 which is based on the NRF52832 which has a different pinout

Board variant is added in sandeepmistry/arduino-nRF5#532 
This PR depends on the above PR for the arduino-nRF5 core