### PR TITLE
Allow programming NRF52840DK using the Adafruit bootloader over nrfutil

### DIFF
--- a/boards/nrf52840_dk_adafruit.json
+++ b/boards/nrf52840_dk_adafruit.json
@@ -52,10 +52,14 @@
     "protocols": [
       "jlink",
       "nrfjprog",
+      "nrfutil",
       "stlink",
       "cmsis-dap",
       "blackmagic"
-    ]
+    ],
+    "use_1200bps_touch": true,
+    "require_upload_port": true,
+    "wait_for_upload_port": true
   },
   "url": "https://os.mbed.com/platforms/Nordic-nRF52840-DK/",
   "vendor": "Nordic"


### PR DESCRIPTION
similar to #66 
the NRF52840DK when programmed with the adafruit bootloader can be flashed over the NRF USB port using nrfutil but will require the 1200bps touch option to automatically enter DFU mode similar to the other adafruit board configurations 