### PR TITLE
Adding NiceNano / ali nRF52840 boards suport

### DIFF
--- a/boards/nicenano.json
+++ b/boards/nicenano.json
@@ -1,0 +1,75 @@
+    {
+  "build": {
+    "arduino":{
+      "ldscript": "nrf52840_s140_v6.ld"
+    },
+    "core": "nRF5",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DNICENANO -DNRF52840_XXAA",
+    "f_cpu": "64000000L",
+    "hwids": [
+      [
+        "0x239A",
+        "0x8029"
+      ],
+      [
+        "0x239A",
+        "0x0029"
+      ],
+      [
+        "0x239A",
+        "0x002A"
+      ],
+      [
+        "0x239A",
+        "0x802A"
+      ]
+    ],
+    "usb_product": "nrf52840",
+    "mcu": "nrf52840",
+    "variant": "nicenano",
+    "bsp": {
+      "name": "adafruit"
+    },
+    "softdevice": {
+      "sd_flags": "-DS140",
+      "sd_name": "s140",
+      "sd_version": "6.1.1",
+      "sd_fwid": "0x00B6"
+    },
+    "bootloader": {
+      "settings_addr": "0xFF000"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "jlink_device": "nRF52840_xxAA",
+    "svd_path": "nrf52840.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr"
+  ],
+  "name": "nicenano",
+  "upload": {
+    "maximum_ram_size": 248832,
+    "maximum_size": 815104,
+    "speed": 115200,
+    "protocol": "nrfutil",
+    "protocols": [
+      "jlink",
+      "nrfjprog",
+      "nrfutil",
+      "stlink",
+      "cmsis-dap",
+      "blackmagic"
+    ],
+    "use_1200bps_touch": true,
+    "require_upload_port": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://icmt.cc/",
+  "vendor": "Aliexpress"
+}


### PR DESCRIPTION
not sure if this will be pulled as it requires being pulled in 2 other repos.

more specifically these 2 pr's:

https://github.com/zephyrproject-rtos/zephyr/pull/99108
https://github.com/adafruit/Adafruit_nRF52_Arduino/pull/857


the repo is from [here](https://github.com/ICantMakeThings/Nicenano-NRF52-Supermini-PlatformIO-Support)